### PR TITLE
Step3

### DIFF
--- a/go/app/main.go
+++ b/go/app/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path"
@@ -20,6 +20,15 @@ type Response struct {
 	Message string `json:"message"`
 }
 
+type Items struct {
+	Items []Item `json:"Items"`
+}
+
+type Item struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+}
+
 func root(c echo.Context) error {
 	res := Response{Message: "Hello, world!"}
 	return c.JSON(http.StatusOK, res)
@@ -28,12 +37,58 @@ func root(c echo.Context) error {
 func addItem(c echo.Context) error {
 	// Get form data
 	name := c.FormValue("name")
+	category := c.FormValue("category")
 	c.Logger().Infof("Receive item: %s", name)
+	c.Logger().Infof("Receive category: %s", category)
 
-	message := fmt.Sprintf("item received: %s", name)
-	res := Response{Message: message}
+	item := Item{Name: name, Category: category}
+	// jsonファイル読み込み
+	inJsonItems, err := os.ReadFile("items.json")
+	if err != nil {
+		log.Fatalf("JSONデータを読み込めませんでした: %v", err)
+	}
+	var inItems Items
+	// 読み込んだファイルが空ではない時構造体にJSONデータを格納
+	if len(inJsonItems) != 0 {
+		err = json.Unmarshal(inJsonItems, &inItems)
+		if err != nil {
+			log.Fatalf("JSONファイルを構造体に変換できませんでした: %v", err)
+		}
+	}
+	inItems.Items = append(inItems.Items, item)
+	// json.MarshalでJSON形式に変換
+	output, err := json.Marshal(&inItems)
+	if err != nil {
+		log.Fatalf("JSON生成中にエラーが発生しました: %v", err)
+	}
+	file, err := os.Create("items.json")
+	if err != nil {
+		log.Fatalf("JSONファイルを開けませんでした: %v", err)
+	}
+	// jsonファイルclose
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			log.Fatalf("ファイルCloseに失敗しました: %v", err)
+		}
+	}(file)
+	// jsonファイル書き込み
+	_, err = file.Write(output)
+	if err != nil {
+		log.Fatalf("JSONファイル書き込み中にエラーが発生しました: %v", err)
+	}
+	// jsonファイル読み込み
+	afterItems, err := os.ReadFile("items.json")
+	if err != nil {
+		log.Fatalf("JSONデータを読み込めませんでした: %v", err)
+	}
+	// terminal上で末尾改行してない時に自動改行の%が付与されるのを防ぐため、あらかじめ改行を付与
+	res := append(afterItems, byte('\n'))
 
-	return c.JSON(http.StatusOK, res)
+	// message := fmt.Sprintf("item received: %s category: %s", name, category)
+
+	// 取得したのがbyte形式だったのでJSON->JSONBlobに変更
+	return c.JSONBlob(http.StatusOK, res)
 }
 
 func getImg(c echo.Context) error {
@@ -73,7 +128,6 @@ func main() {
 	e.POST("/items", addItem)
 	e.GET("/image/:imageFilename", getImg)
 
-
 	// Start server
-	e.Logger.Fatal(e.Start(":9000"))
+	e.Logger.Fatal(e.Start("127.0.0.1:9000"))
 }

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -77,6 +77,13 @@ func addItem(c echo.Context) error {
 	if err != nil {
 		log.Fatalf("JSONファイル書き込み中にエラーが発生しました: %v", err)
 	}
+
+	res := Response{Message: "書き込みが正常に完了しました。"}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+func getItems(c echo.Context) error {
 	// jsonファイル読み込み
 	afterItems, err := os.ReadFile("items.json")
 	if err != nil {
@@ -84,8 +91,6 @@ func addItem(c echo.Context) error {
 	}
 	// terminal上で末尾改行してない時に自動改行の%が付与されるのを防ぐため、あらかじめ改行を付与
 	res := append(afterItems, byte('\n'))
-
-	// message := fmt.Sprintf("item received: %s category: %s", name, category)
 
 	// 取得したのがbyte形式だったのでJSON->JSONBlobに変更
 	return c.JSONBlob(http.StatusOK, res)
@@ -125,6 +130,7 @@ func main() {
 
 	// Routes
 	e.GET("/", root)
+	e.GET("/items", getItems)
 	e.POST("/items", addItem)
 	e.GET("/image/:imageFilename", getImg)
 

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -25,8 +32,46 @@ type Items struct {
 }
 
 type Item struct {
-	Name     string `json:"name"`
-	Category string `json:"category"`
+	Name      string `json:"name"`
+	Category  string `json:"category"`
+	ImageName string `json:"imageName"`
+}
+
+func copyfile(img *multipart.FileHeader) (string, error) {
+	imgName := img.Filename
+	// 先頭から(元の長さ-拡張子の長さ)だけ取得
+	imgBaseName := imgName[:len(imgName)-len(filepath.Ext(imgName))]
+	// 拡張子を除いたファイル名でhash値を生成
+	s := sha256.New()
+	_, err := io.WriteString(s, imgBaseName)
+	if err != nil {
+		return "", fmt.Errorf("sha256に変換できませんでした: %v", err)
+	}
+	// 拡張子をつけるとともにsが[]byteなのでstringに変換
+	newFileName := hex.EncodeToString(s.Sum(nil)) + filepath.Ext(imgName)
+	// ファイルパスを指定して名前をhash化したファイルを生成
+	newFile, err := os.Create("images/" + newFileName)
+	if err != nil {
+		return "", fmt.Errorf("新しい画像ファイルの生成に失敗しました: %v", err)
+	}
+	// 既存のimgファイルを開く
+	originalFile, err := img.Open()
+	if err != nil {
+		return "", fmt.Errorf("元画像ファイルの読み込みに失敗しました: %v", err)
+	}
+	// originalファイルclose
+	defer func(file multipart.File) {
+		err := file.Close()
+		if err != nil {
+			log.Fatalf("ファイルCloseに失敗しました: %v", err)
+		}
+	}(originalFile)
+	// 新しいファイルに既存のデータをコピー
+	_, err = io.Copy(newFile, originalFile)
+	if err != nil {
+		return "", fmt.Errorf("ファイルのコピーに失敗しました: %v", err)
+	}
+	return newFileName, err
 }
 
 func root(c echo.Context) error {
@@ -38,29 +83,42 @@ func addItem(c echo.Context) error {
 	// Get form data
 	name := c.FormValue("name")
 	category := c.FormValue("category")
+	img, err := c.FormFile("image")
+	if err != nil {
+		log.Fatalf("画像の受け取りに失敗しました: %v", err)
+	}
+	// 入手したファイルから名前をhash化したファイルを生成
+	newFileName, err := copyfile(img)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	c.Logger().Infof("Receive item: %s", name)
 	c.Logger().Infof("Receive category: %s", category)
+	c.Logger().Infof("Receive imageFile: %s", newFileName)
 
-	item := Item{Name: name, Category: category}
+	item := Item{Name: name, Category: category, ImageName: newFileName}
 	// jsonファイル読み込み
 	inJsonItems, err := os.ReadFile("items.json")
 	if err != nil {
 		log.Fatalf("JSONデータを読み込めませんでした: %v", err)
 	}
 	var inItems Items
-	// 読み込んだファイルが空ではない時構造体にJSONデータを格納
+	// 読み込んだファイルが空ではない時JSONを構造体に変換
 	if len(inJsonItems) != 0 {
 		err = json.Unmarshal(inJsonItems, &inItems)
 		if err != nil {
 			log.Fatalf("JSONファイルを構造体に変換できませんでした: %v", err)
 		}
 	}
+	// 構造体にformの値を追加
 	inItems.Items = append(inItems.Items, item)
 	// json.MarshalでJSON形式に変換
 	output, err := json.Marshal(&inItems)
 	if err != nil {
 		log.Fatalf("JSON生成中にエラーが発生しました: %v", err)
 	}
+	// jsonファイルを作成、すでにある場合はクリアして開く
 	file, err := os.Create("items.json")
 	if err != nil {
 		log.Fatalf("JSONファイルを開けませんでした: %v", err)
@@ -96,6 +154,34 @@ func getItems(c echo.Context) error {
 	return c.JSONBlob(http.StatusOK, res)
 }
 
+func getItemById(c echo.Context) error {
+	// jsonファイル読み込み
+	inJsonItems, err := os.ReadFile("items.json")
+	if err != nil {
+		log.Fatalf("JSONデータを読み込めませんでした: %v", err)
+	}
+	var inItems Items
+	// 読み込んだファイルが空の時早期return
+	if len(inJsonItems) == 0 {
+		res := Response{Message: "itemはまだ登録されていません"}
+		return c.JSON(http.StatusOK, res)
+	}
+	err = json.Unmarshal(inJsonItems, &inItems)
+	if err != nil {
+		log.Fatalf("JSONファイルを構造体に変換できませんでした: %v", err)
+	}
+	index, err := strconv.Atoi(c.Param("item_id"))
+	if err != nil {
+		log.Fatalf("idの取得に失敗しました: %v", err)
+	}
+	if len(inItems.Items) <= index {
+		res := Response{Message: "存在しないIDです"}
+		return c.JSON(http.StatusOK, res)
+	}
+	res := inItems.Items[index]
+	return c.JSON(http.StatusOK, res)
+}
+
 func getImg(c echo.Context) error {
 	// Create image path
 	imgPath := path.Join(ImgDir, c.Param("imageFilename"))
@@ -105,7 +191,7 @@ func getImg(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, res)
 	}
 	if _, err := os.Stat(imgPath); err != nil {
-		c.Logger().Debugf("Image not found: %s", imgPath)
+		c.Logger().Infof("Image not found: %s", imgPath)
 		imgPath = path.Join(ImgDir, "default.jpg")
 	}
 	return c.File(imgPath)
@@ -132,6 +218,7 @@ func main() {
 	e.GET("/", root)
 	e.GET("/items", getItems)
 	e.POST("/items", addItem)
+	e.GET("/items/:item_id", getItemById)
 	e.GET("/image/:imageFilename", getImg)
 
 	// Start server


### PR DESCRIPTION
## What
step3-1 ~ step3-6を実行しました。詳しい背景については[STEP:3出品APIを作る](https://github.com/yamamoto99/mercari-build-training/blob/main/document/03-api.ja.md)を参照してください。
## Why
これらの変更によりユーザーはitemの登録、登録情報の確認ができるようになります。
## Who
JSONファイルを作成し、itemを格納。それを読み込むことによって一時的な戻り値を取得してます。
## Testing
`main.go`を実行し`curl`を利用し、ターミナル上で戻り値を参照してください。
```shell
# アプリケーションの起動
go run app/main.go
```

```shell
# 新規アイテム登録
# ファイルパスに注意してください
# このテストコードは現在地が/mercari-build-training/goであることを前提としています
curl -X POST \
  --url 'http://localhost:9000/items' \
  -F 'name=jacket' \
  -F 'category=fashion' \
  -F 'image=@images/default.jpg' 
```
```shell
# item一覧を取得
curl -X GET 'http://127.0.0.1:9000/items'
```
```shell
# 指定したIDの商品情報を取得
# 必要に応じて渡すIDを変更してください
curl -X GET 'http://127.0.0.1:9000/items/1'
```

## Please review
- エラー処理を個々で入れているのでコードが冗長に感じてしまう。パッケージ化などの方法があることは理解してるが、単純に1つの関数が長い。
- deferでファイルをcloseしているが、エラー処理に`c.Logger().Fatalf()`を利用しているため、エラー時ファイルがcloseされずに処理が終了してしまう。しかし、`c.Logger().Infof()`などを利用すると前提値が取得できてないのに処理が継続されるため、後続で予期せぬエラーが発生してしまう。closeを関数化すべき？
- item登録時に`JSON->構造体->構造体に格納->JSON`という順序で処理を行っているが、もっとスマートに記述できないか
## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
